### PR TITLE
Add support for images, videos, and actions to Teams webhooks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,20 @@
       <artifactId>gson</artifactId>
       <version>2.13.2</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.11.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.11.4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.n1netails</groupId>
   <artifactId>n1netails-teams-webhook-client</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <packaging>jar</packaging>
 
   <name>n1netails-teams-webhook-client</name>

--- a/readme.md
+++ b/readme.md
@@ -47,13 +47,13 @@ Install the teams webhook client by adding the following dependency:
 <dependency>
     <groupId>com.n1netails</groupId>
     <artifactId>n1netails-teams-webhook-client</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
 </dependency>
 ```
 
 Gradle (Groovy)
 ```groovy
-implementation 'com.n1netails:n1netails-teams-webhook-client:0.2.0'
+implementation 'com.n1netails:n1netails-teams-webhook-client:0.3.0'
 ```
 
 ## Usage
@@ -75,6 +75,14 @@ public class Example {
 
             WebhookMessage message = new WebhookMessage();
             message.setContent("Hello, from n1netails-teams-webhook-client!");
+            message.setImageUrl("https://raw.githubusercontent.com/n1netails/n1netails/refs/heads/main/n1netails_icon_transparent.png");
+            // Gifs are also supported
+            // message.setImageUrl("https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNHJndXh6cnVreHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4JmVwPXYxX2ludGVybmFsX2dpZl9ieV9pZCZjdD1n/3o7TKSjPQC1IdRWH1C/giphy.gif");
+            message.setVideoUrl("https://www.w3schools.com/html/mov_bbb.mp4");
+
+            List<Action> actions = new ArrayList<>();
+            actions.add(new Action("Visit Website", "https://github.com/n1netails/n1netails-teams-webhook-client"));
+            message.setActions(actions);
 
             client.sendMessage("YOUR_WEBHOOK_URL", message);
         } catch (Exception e) {
@@ -94,12 +102,11 @@ The message card is a more flexible and customizable way to send messages.
 ```java
 import com.n1netails.n1netails.teams.api.TeamsWebhookClient;
 import com.n1netails.n1netails.teams.internal.TeamsWebhookClientImpl;
-import com.n1netails.n1netails.teams.model.Fact;
-import com.n1netails.n1netails.teams.model.MessageCard;
-import com.n1netails.n1netails.teams.model.Section;
+import com.n1netails.n1netails.teams.model.*;
 import com.n1netails.n1netails.teams.service.WebhookService;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class Example {
@@ -120,9 +127,14 @@ public class Example {
             facts.add(new Fact("Fact 1", "Fact 1 Value"));
             facts.add(new Fact("Fact 2", "Fact 2 Value"));
             section.setFacts(facts);
+            section.setImageUrl("https://raw.githubusercontent.com/n1netails/n1netails/refs/heads/main/n1netails_icon_transparent.png");
             sections.add(section);
 
             messageCard.setSections(sections);
+
+            List<Action> actions = new ArrayList<>();
+            actions.add(new Action("View Website", "https://github.com/n1netails/n1netails-teams-webhook-client"));
+            messageCard.setActions(actions);
 
             client.sendMessage("YOUR_WEBHOOK_URL", messageCard);
         } catch (Exception e) {

--- a/src/main/java/com/n1netails/n1netails/teams/model/Action.java
+++ b/src/main/java/com/n1netails/n1netails/teams/model/Action.java
@@ -1,0 +1,29 @@
+package com.n1netails.n1netails.teams.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Action for MessageCard
+ */
+@Getter
+@Setter
+public class Action {
+    private String name;
+    private String target;
+
+    /**
+     * Action Constructor
+     */
+    public Action() {}
+
+    /**
+     * Action Constructor with parameters
+     * @param name Name of the action
+     * @param target Target URL of the action
+     */
+    public Action(String name, String target) {
+        this.name = name;
+        this.target = target;
+    }
+}

--- a/src/main/java/com/n1netails/n1netails/teams/model/MessageCard.java
+++ b/src/main/java/com/n1netails/n1netails/teams/model/MessageCard.java
@@ -18,6 +18,7 @@ public class MessageCard {
     private String title;
     private String summary;
     private List<Section> sections;
+    private List<Action> actions;
 
     /**
      * Message Card Constructor

--- a/src/main/java/com/n1netails/n1netails/teams/model/Section.java
+++ b/src/main/java/com/n1netails/n1netails/teams/model/Section.java
@@ -14,6 +14,8 @@ public class Section {
 
     private String title;
     private List<Fact> facts;
+    private String imageUrl;
+    private String videoUrl;
 
     /**
      * Section Constructor

--- a/src/main/java/com/n1netails/n1netails/teams/model/WebhookMessage.java
+++ b/src/main/java/com/n1netails/n1netails/teams/model/WebhookMessage.java
@@ -3,6 +3,8 @@ package com.n1netails.n1netails.teams.model;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 /**
  * Teams Webhook Message
  * @author shahid foy
@@ -14,6 +16,7 @@ public class WebhookMessage {
     private String content;
     private String imageUrl;
     private String videoUrl;
+    private List<Action> actions;
 
     /**
      * Webhook Message Constructor

--- a/src/main/java/com/n1netails/n1netails/teams/model/WebhookMessage.java
+++ b/src/main/java/com/n1netails/n1netails/teams/model/WebhookMessage.java
@@ -12,6 +12,8 @@ import lombok.Setter;
 public class WebhookMessage {
 
     private String content;
+    private String imageUrl;
+    private String videoUrl;
 
     /**
      * Webhook Message Constructor

--- a/src/main/java/com/n1netails/n1netails/teams/model/WebhookPayload.java
+++ b/src/main/java/com/n1netails/n1netails/teams/model/WebhookPayload.java
@@ -45,6 +45,7 @@ public class WebhookPayload {
         private String type;
         private String version;
         private List<BodyItem> body;
+        private List<ActionItem> actions;
 
         /**
          * Content Constructor
@@ -80,10 +81,43 @@ public class WebhookPayload {
         private String size;
         private boolean wrap;
         private boolean separator;
+        private String url;
+        private List<MediaSource> sources;
 
         /**
          * Body Item Constructor
          */
         public BodyItem() {}
+    }
+
+    /**
+     * Media Source
+     */
+    @Setter
+    @Getter
+    public static class MediaSource {
+        private String mimeType;
+        private String url;
+
+        /**
+         * Media Source Constructor
+         */
+        public MediaSource() {}
+    }
+
+    /**
+     * Action Item
+     */
+    @Setter
+    @Getter
+    public static class ActionItem {
+        private String type;
+        private String title;
+        private String url;
+
+        /**
+         * Action Item Constructor
+         */
+        public ActionItem() {}
     }
 }

--- a/src/main/java/com/n1netails/n1netails/teams/service/WebhookService.java
+++ b/src/main/java/com/n1netails/n1netails/teams/service/WebhookService.java
@@ -25,6 +25,9 @@ public class WebhookService {
     public static final String TEXT_BLOCK = "TextBlock";
     public static final String BOLDER = "Bolder";
     public static final String MEDIUM = "Medium";
+    public static final String IMAGE = "Image";
+    public static final String MEDIA = "Media";
+    public static final String ACTION_OPEN_URL = "Action.OpenUrl";
 
     private final Gson gson = new Gson();
 
@@ -80,7 +83,7 @@ public class WebhookService {
         }
     }
 
-    private static WebhookPayload getWebhookPayload(WebhookMessage message) {
+    public static WebhookPayload getWebhookPayload(WebhookMessage message) {
         WebhookPayload payload = new WebhookPayload();
         WebhookPayload.Attachment attachment = new WebhookPayload.Attachment();
         attachment.setContentType(APPLICATION_VND_MICROSOFT_CARD_ADAPTIVE);
@@ -99,13 +102,33 @@ public class WebhookService {
         content.set$schema(HTTP_ADAPTIVECARDS_IO_SCHEMAS_ADAPTIVE_CARD_JSON);
         content.setType(ADAPTIVE_CARD);
         content.setVersion(VERSION);
-        WebhookPayload.BodyItem bodyItem = new WebhookPayload.BodyItem();
-        bodyItem.setType(TEXT_BLOCK);
-        bodyItem.setText(message.getContent());
-        bodyItem.setWeight(BOLDER);
-        bodyItem.setSize(MEDIUM);
         List<WebhookPayload.BodyItem> bodyItems = new ArrayList<>();
-        bodyItems.add(bodyItem);
+
+        if (message.getContent() != null) {
+            WebhookPayload.BodyItem bodyItem = new WebhookPayload.BodyItem();
+            bodyItem.setType(TEXT_BLOCK);
+            bodyItem.setText(message.getContent());
+            bodyItem.setWeight(BOLDER);
+            bodyItem.setSize(MEDIUM);
+            bodyItems.add(bodyItem);
+        }
+
+        if (message.getImageUrl() != null) {
+            WebhookPayload.BodyItem imageItem = new WebhookPayload.BodyItem();
+            imageItem.setType(IMAGE);
+            imageItem.setUrl(message.getImageUrl());
+            bodyItems.add(imageItem);
+        }
+
+        if (message.getVideoUrl() != null) {
+            WebhookPayload.BodyItem mediaItem = new WebhookPayload.BodyItem();
+            mediaItem.setType(MEDIA);
+            WebhookPayload.MediaSource source = new WebhookPayload.MediaSource();
+            source.setUrl(message.getVideoUrl());
+            mediaItem.setSources(Collections.singletonList(source));
+            bodyItems.add(mediaItem);
+        }
+
         content.setBody(bodyItems);
         return content;
     }
@@ -175,7 +198,35 @@ public class WebhookService {
                         body.add(factBlock);
                     }
                 }
+
+                if (section.getImageUrl() != null) {
+                    WebhookPayload.BodyItem imageItem = new WebhookPayload.BodyItem();
+                    imageItem.setType(IMAGE);
+                    imageItem.setUrl(section.getImageUrl());
+                    body.add(imageItem);
+                }
+
+                if (section.getVideoUrl() != null) {
+                    WebhookPayload.BodyItem mediaItem = new WebhookPayload.BodyItem();
+                    mediaItem.setType(MEDIA);
+                    WebhookPayload.MediaSource source = new WebhookPayload.MediaSource();
+                    source.setUrl(section.getVideoUrl());
+                    mediaItem.setSources(Collections.singletonList(source));
+                    body.add(mediaItem);
+                }
             }
+        }
+
+        if (card.getActions() != null) {
+            List<WebhookPayload.ActionItem> actions = new ArrayList<>();
+            for (Action action : card.getActions()) {
+                WebhookPayload.ActionItem actionItem = new WebhookPayload.ActionItem();
+                actionItem.setType(ACTION_OPEN_URL);
+                actionItem.setTitle(action.getName());
+                actionItem.setUrl(action.getTarget());
+                actions.add(actionItem);
+            }
+            content.setActions(actions);
         }
 
         content.setBody(body);

--- a/src/main/java/com/n1netails/n1netails/teams/service/WebhookService.java
+++ b/src/main/java/com/n1netails/n1netails/teams/service/WebhookService.java
@@ -129,6 +129,18 @@ public class WebhookService {
             bodyItems.add(mediaItem);
         }
 
+        if (message.getActions() != null) {
+            List<WebhookPayload.ActionItem> actions = new ArrayList<>();
+            for (Action action : message.getActions()) {
+                WebhookPayload.ActionItem actionItem = new WebhookPayload.ActionItem();
+                actionItem.setType(ACTION_OPEN_URL);
+                actionItem.setTitle(action.getName());
+                actionItem.setUrl(action.getTarget());
+                actions.add(actionItem);
+            }
+            content.setActions(actions);
+        }
+
         content.setBody(bodyItems);
         return content;
     }

--- a/src/test/java/com/n1netails/n1netails/teams/service/WebhookServiceTest.java
+++ b/src/test/java/com/n1netails/n1netails/teams/service/WebhookServiceTest.java
@@ -1,0 +1,89 @@
+package com.n1netails.n1netails.teams.service;
+
+import com.google.gson.Gson;
+import com.n1netails.n1netails.teams.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WebhookServiceTest {
+
+    private final Gson gson = new Gson();
+
+    @Test
+    public void testGetWebhookPayloadFromWebhookMessage() {
+        WebhookMessage message = new WebhookMessage();
+        message.setContent("Test Content");
+        message.setImageUrl("http://example.com/image.png");
+        message.setVideoUrl("http://example.com/video.mp4");
+
+        WebhookPayload payload = WebhookService.getWebhookPayload(message);
+
+        assertNotNull(payload);
+        assertEquals(1, payload.getAttachments().size());
+        WebhookPayload.Attachment attachment = payload.getAttachments().get(0);
+        assertEquals(WebhookService.APPLICATION_VND_MICROSOFT_CARD_ADAPTIVE, attachment.getContentType());
+
+        WebhookPayload.Content content = attachment.getContent();
+        assertEquals(WebhookService.HTTP_ADAPTIVECARDS_IO_SCHEMAS_ADAPTIVE_CARD_JSON, content.get$schema());
+        assertEquals(WebhookService.ADAPTIVE_CARD, content.getType());
+        assertEquals(WebhookService.VERSION, content.getVersion());
+
+        assertEquals(3, content.getBody().size());
+
+        WebhookPayload.BodyItem textItem = content.getBody().get(0);
+        assertEquals(WebhookService.TEXT_BLOCK, textItem.getType());
+        assertEquals("Test Content", textItem.getText());
+
+        WebhookPayload.BodyItem imageItem = content.getBody().get(1);
+        assertEquals(WebhookService.IMAGE, imageItem.getType());
+        assertEquals("http://example.com/image.png", imageItem.getUrl());
+
+        WebhookPayload.BodyItem mediaItem = content.getBody().get(2);
+        assertEquals(WebhookService.MEDIA, mediaItem.getType());
+        assertNotNull(mediaItem.getSources());
+        assertEquals(1, mediaItem.getSources().size());
+        assertEquals("http://example.com/video.mp4", mediaItem.getSources().get(0).getUrl());
+    }
+
+    @Test
+    public void testGetWebhookPayloadFromMessageCard() {
+        MessageCard card = new MessageCard();
+        card.setTitle("Test Title");
+        card.setSummary("Test Summary");
+
+        Section section = new Section();
+        section.setTitle("Section Title");
+        section.setImageUrl("http://example.com/section-image.png");
+        section.setVideoUrl("http://example.com/section-video.mp4");
+        card.setSections(Collections.singletonList(section));
+
+        Action action = new Action("View More", "http://example.com");
+        card.setActions(Collections.singletonList(action));
+
+        WebhookPayload payload = WebhookService.getWebhookPayload(card);
+
+        assertNotNull(payload);
+        WebhookPayload.Content content = payload.getAttachments().get(0).getContent();
+
+        assertEquals(5, content.getBody().size());
+        assertEquals("Test Title", content.getBody().get(0).getText());
+        assertEquals("Test Summary", content.getBody().get(1).getText());
+        assertEquals("Section Title", content.getBody().get(2).getText());
+
+        assertEquals(WebhookService.IMAGE, content.getBody().get(3).getType());
+        assertEquals("http://example.com/section-image.png", content.getBody().get(3).getUrl());
+
+        assertEquals(WebhookService.MEDIA, content.getBody().get(4).getType());
+        assertEquals("http://example.com/section-video.mp4", content.getBody().get(4).getSources().get(0).getUrl());
+
+        assertNotNull(content.getActions());
+        assertEquals(1, content.getActions().size());
+        assertEquals(WebhookService.ACTION_OPEN_URL, content.getActions().get(0).getType());
+        assertEquals("View More", content.getActions().get(0).getTitle());
+        assertEquals("http://example.com", content.getActions().get(0).getUrl());
+    }
+}

--- a/src/test/java/com/n1netails/n1netails/teams/service/WebhookServiceTest.java
+++ b/src/test/java/com/n1netails/n1netails/teams/service/WebhookServiceTest.java
@@ -11,8 +11,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class WebhookServiceTest {
 
-    private final Gson gson = new Gson();
-
     @Test
     public void testGetWebhookPayloadFromWebhookMessage() {
         WebhookMessage message = new WebhookMessage();

--- a/src/test/java/com/n1netails/n1netails/teams/service/WebhookServiceTest.java
+++ b/src/test/java/com/n1netails/n1netails/teams/service/WebhookServiceTest.java
@@ -17,6 +17,7 @@ public class WebhookServiceTest {
         message.setContent("Test Content");
         message.setImageUrl("http://example.com/image.png");
         message.setVideoUrl("http://example.com/video.mp4");
+        message.setActions(Collections.singletonList(new Action("Action", "http://example.com")));
 
         WebhookPayload payload = WebhookService.getWebhookPayload(message);
 
@@ -45,6 +46,10 @@ public class WebhookServiceTest {
         assertNotNull(mediaItem.getSources());
         assertEquals(1, mediaItem.getSources().size());
         assertEquals("http://example.com/video.mp4", mediaItem.getSources().get(0).getUrl());
+
+        assertNotNull(content.getActions());
+        assertEquals(1, content.getActions().size());
+        assertEquals("Action", content.getActions().get(0).getTitle());
     }
 
     @Test


### PR DESCRIPTION
This change updates the Teams Webhook Client library to support sending images, GIFs (via imageUrl), videos (via videoUrl), and call-to-action buttons. 

Key changes:
- New fields `imageUrl` and `videoUrl` added to `WebhookMessage` and `Section`.
- New `Action` model and `actions` list added to `MessageCard` for interactive buttons.
- Updated the underlying `WebhookPayload` and `WebhookService` to correctly serialize these new elements into the Microsoft Teams Adaptive Card format (version 1.4).
- Added unit tests in `WebhookServiceTest` to ensure correct JSON payload generation for both simple messages and complex message cards with rich media and actions.
- Integrated JUnit 5 for testing.

---
*PR created automatically by Jules for task [7828470802488175843](https://jules.google.com/task/7828470802488175843) started by @shahidfoy*